### PR TITLE
Remove Dockerfile* from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@ node_modules
 npm-debug.log
 dist
 .dockerignore
-Dockerfile*
 .git
 .gitignore
 README.md


### PR DESCRIPTION
No longer ignoring Dockerfile, as this caused problems when building
through PyCharm.