### PR TITLE
Add basic overview panel

### DIFF
--- a/src/components/OverviewPanel.js
+++ b/src/components/OverviewPanel.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const OverviewPanel = ({ document, sectionData, open, onClick, activeField, onMouseEnter, onMouseLeave }) => (
+  <div className={`overview-panel ${open ? 'open' : ''}`} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+    {open ? (
+      <button type="button" onClick={() => onClick(document.id)} disabled={activeField === document.id}>
+        {document.title !== '' ? document.title : 'Skriv inn dokumenttittel'}
+      </button>
+    ) : (
+      <p>--------------------</p>
+    )}
+    {sectionData.map((section, index) => (
+      <div
+        key={section.id}
+        className={`overview-panel__section ${activeField === `${section.id}-title` ? 'active' : ''}`}
+      >
+        {!section.isHidden && (
+          <React.Fragment>
+            {open ? (
+              <button
+                type="button"
+                onClick={() => onClick(`${section.id}-title`)}
+                disabled={activeField === `${section.id}-title`}
+              >
+                {section.title === '' ? `Seksjonstittel ${index + 1}` : section.title}
+              </button>
+            ) : (
+              <p>----------------</p>
+            )}
+          </React.Fragment>
+        )}
+        {section.questions.map(({ id, title }) => (
+          <React.Fragment key={id}>
+            {title !== '' && (
+              <div className={`overview-panel__question ${activeField === id ? 'active' : ''}`}>
+                {open ? (
+                  <button type="button" onClick={() => onClick(id)} disabled={activeField === id}>
+                    {title}
+                  </button>
+                ) : (
+                  <p>------------</p>
+                )}
+              </div>
+            )}
+          </React.Fragment>
+        ))}
+      </div>
+    ))}
+  </div>
+);
+
+OverviewPanel.propTypes = {
+  document: PropTypes.shape({ id: PropTypes.string, title: PropTypes.string }).isRequired,
+  sectionData: PropTypes.arrayOf(PropTypes.object).isRequired,
+  open: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
+  activeField: PropTypes.string.isRequired,
+  onMouseEnter: PropTypes.func.isRequired,
+  onMouseLeave: PropTypes.func.isRequired,
+};
+
+export default OverviewPanel;

--- a/src/containers/FormDesignerContainer.js
+++ b/src/containers/FormDesignerContainer.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import DocumentContainer from './DocumentContainer';
+import OverviewPanelContainer from './OverviewPanelContainer';
 
 const FormDesignerContainer = () => (
   <div className="form-designer-container">
+    <OverviewPanelContainer />
     <DocumentContainer />
   </div>
 );

--- a/src/containers/OverviewPanelContainer.js
+++ b/src/containers/OverviewPanelContainer.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { setFocus } from '../actions/documentActions';
+import OverviewPanel from '../components/OverviewPanel';
+
+class OverviewPanelContainer extends React.Component {
+  state = {
+    open: false,
+  };
+
+  handleClick = id => {
+    const { setFocusTo } = this.props;
+    setFocusTo(id);
+  };
+
+  handleMouseEnter = () => {
+    this.setState({ open: true });
+  };
+
+  handleMouseLeave = () => {
+    this.setState({ open: false });
+  };
+
+  render() {
+    const { document, sections, questions, activeField } = this.props;
+    const { open } = this.state;
+    const overviewData = sections.map(section => ({
+      id: section.id,
+      title: section.title.text,
+      isHidde: section.title.isHidden,
+      questions: questions.map(question => {
+        if (section.questions.includes(question.id)) {
+          return { id: question.id, title: question.title };
+        }
+        return null;
+      }),
+    }));
+    return (
+      <OverviewPanel
+        document={document}
+        sectionData={overviewData}
+        open={open}
+        onClick={this.handleClick}
+        activeField={activeField}
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
+      />
+    );
+  }
+}
+
+OverviewPanelContainer.propTypes = {
+  document: PropTypes.shape({ id: PropTypes.string, title: PropTypes.string }).isRequired,
+  sections: PropTypes.arrayOf(PropTypes.object).isRequired,
+  questions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  setFocusTo: PropTypes.func.isRequired,
+  activeField: PropTypes.string.isRequired,
+};
+
+const mapStateToProps = state => ({
+  document: { id: state.document.id, title: state.document.title },
+  sections: state.sections,
+  questions: state.questions,
+  activeField: state.document.activeField,
+});
+
+const mapDispatchToProps = dispatch => ({
+  setFocusTo: id => dispatch(setFocus(id)),
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(OverviewPanelContainer);

--- a/src/styles/_formDesigner.scss
+++ b/src/styles/_formDesigner.scss
@@ -1,3 +1,7 @@
+.form-designer-container  {
+  height: 100%;
+}
+
 .document-container {
   min-height: 90vh;
   max-width: 80%;
@@ -6,4 +10,30 @@
   background-color: #fff;
   border-radius: 0.3% 0.3% 0 0;
   box-shadow: 0 2px 7px 1px rgba(0, 0, 0, 0.5);
+}
+
+.overview-panel {
+  margin: -10vh 0 0 0;
+  height: 100%;
+  width: 10rem;
+  left: -3rem;
+  // border: 1px solid #ccc;
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  button {
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 10px;
+    border: none;
+    background: none;
+  }
+
+  &.open {
+    left: 0;
+  }
 }


### PR DESCRIPTION
This branch will add a basic overview panel that uses activeField in state to decide which field that is active. The panel should probably use the elements position in the view instead, but I don't think we have time to implement it...